### PR TITLE
Use Velocity soft-mirror rather than development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Create tests in your tests directory `tests/casperjs/[*.js|*.coffee]`
 Sample file:
 ```coffeescript
 casper.test.begin "Sample Test", 2, (test) ->
-   casper.start "http://localhost:3000", ->
+   casper.start casper.cli.get('rootUrl'), ->
       @waitForSelector "body", ->
          test.assert true, "True is true"
 
@@ -25,3 +25,5 @@ casper.test.begin "Sample Test", 2, (test) ->
 Integrates with [velocity:html-reporter](https://github.com/meteor-velocity/html-reporter/).
 
 Run your tests with `meteor run --test`.
+
+In your tests, parse the `--rootUrl=<URL>` option with `casper.cli.get('rootUrl')` to hit the [soft-mirror](https://github.com/meteor-velocity/node-soft-mirror).

--- a/package.js
+++ b/package.js
@@ -18,6 +18,7 @@ Package.onUse(function(api) {
       'velocity:shim@0.0.3',
       'coffeescript'
    ], 'server');
+   api.use("velocity:node-soft-mirror@0.2.6", { unordered: true });
    api.addFiles('nblazer:casperjs.coffee', 'server');
    api.addFiles('sample-tests/sampleTest.coffee', 'server', {isAsset: true});
 });


### PR DESCRIPTION
This change creates a mirror for CasperJS and passes the `rootUrl`
to the tests as a CLI argument, so that tests can be safely isolated
from the development environment.